### PR TITLE
Update knxd_args.cpp

### DIFF
--- a/src/server/knxd_args.cpp
+++ b/src/server/knxd_args.cpp
@@ -390,7 +390,7 @@ static struct argp_option options[] = {
   {"no-tunnel-client-queuing", OPT_BACK_TUNNEL_NOQUEUE, 0, 0,
    "wait 30msec between transmitting packets. Obsolete, please use --send-delay=30"},
 #endif
-#if defined(HAVE_TPUARTs) || defined(HAVE_TPUARTs_TCP)
+#if defined(HAVE_TPUART) || defined(HAVE_TPUARTs_TCP)
   {"tpuarts-ack-all-group", OPT_BACK_TPUARTS_ACKGROUP, 0, 0,
    "tpuarts backend should generate L2 acks for all group telegrams"},
   {"tpuarts-ack-all-individual", OPT_BACK_TPUARTS_ACKINDIVIDUAL, 0, 0,


### PR DESCRIPTION
Fixed misspelled HAVE_TPUART (was HAVE_TPUARTs in knxd_args.cpp, but HAVE_TPUART in configure.ac)